### PR TITLE
fix: Allow custom http status codes

### DIFF
--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientResponseActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientResponseActionBuilder.java
@@ -26,6 +26,7 @@ import org.citrusframework.http.message.HttpMessageUtils;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.builder.ReceiveMessageBuilderSupport;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 
 /**
  * @author Christoph Deppisch
@@ -95,7 +96,7 @@ public class HttpClientResponseActionBuilder extends ReceiveMessageAction.Receiv
          * @return
          */
         public HttpMessageBuilderSupport statusCode(Integer statusCode) {
-            httpMessage.statusCode(statusCode);
+            httpMessage.status(HttpStatusCode.valueOf(statusCode));
             return this;
         }
 

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpServerResponseActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpServerResponseActionBuilder.java
@@ -25,6 +25,7 @@ import org.citrusframework.http.message.HttpMessageUtils;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.builder.SendMessageBuilderSupport;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 
 /**
  * @author Christoph Deppisch
@@ -93,7 +94,7 @@ public class HttpServerResponseActionBuilder extends SendMessageAction.SendMessa
          * @return
          */
         public HttpMessageBuilderSupport statusCode(Integer statusCode) {
-            httpMessage.statusCode(statusCode);
+            httpMessage.status(HttpStatusCode.valueOf(statusCode));
             return this;
         }
 

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/controller/HttpMessageController.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/controller/HttpMessageController.java
@@ -31,10 +31,7 @@ import org.citrusframework.http.client.HttpEndpointConfiguration;
 import org.citrusframework.http.message.HttpMessage;
 import org.citrusframework.http.server.HttpServerSettings;
 import org.citrusframework.message.Message;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -179,7 +176,7 @@ public class HttpMessageController {
             }
 
             if (httpResponse.getStatusCode() == null) {
-                httpResponse.status(HttpStatus.valueOf(endpointConfiguration.getDefaultStatusCode()));
+                httpResponse.status(HttpStatusCode.valueOf(endpointConfiguration.getDefaultStatusCode()));
             }
 
             responseEntity = (ResponseEntity<?>) endpointConfiguration.getMessageConverter().convertOutbound(httpResponse, endpointConfiguration, null);

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageConverter.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageConverter.java
@@ -16,10 +16,7 @@
 
 package org.citrusframework.http.message;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.http.client.HttpEndpointConfiguration;
@@ -28,11 +25,7 @@ import org.citrusframework.message.MessageConverter;
 import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.message.MessageHeaders;
 import jakarta.servlet.http.Cookie;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -91,7 +84,7 @@ public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, Htt
         }
 
         if (message instanceof ResponseEntity<?>) {
-            httpMessage.status(HttpStatus.valueOf(((ResponseEntity<?>) message).getStatusCode().value()));
+            httpMessage.status(((ResponseEntity<?>) message).getStatusCode());
 
             // We've no information here about the HTTP Version in this context.
             // Because HTTP/2 is not supported anyway currently, this should be acceptable.

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageConverterTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageConverterTest.java
@@ -20,12 +20,7 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.http.client.HttpEndpointConfiguration;
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.messaging.MessageHeaders;
 import org.testng.annotations.BeforeMethod;
@@ -320,6 +315,19 @@ public class HttpMessageConverterTest {
     }
 
     @Test
+    public void testCustomStatusCodeIsSetOnOutbound(){
+
+        //GIVEN
+        message.setHeader(HttpMessageHeaders.HTTP_STATUS_CODE, "555");
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(HttpStatusCode.valueOf(555), ((ResponseEntity<?>) httpEntity).getStatusCode());
+    }
+
+    @Test
     public void testSpringIntegrationHeaderMapperIsUsedOnOutbound(){
 
         //GIVEN
@@ -441,6 +449,20 @@ public class HttpMessageConverterTest {
 
         //THEN
         assertEquals(HttpStatus.FORBIDDEN, httpMessage.getStatusCode());
+    }
+
+    @Test
+    public void testCustomStatusCodeIsSetOnInbound(){
+
+        //GIVEN
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(null, null, 555);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(HttpStatusCode.valueOf(555), httpMessage.getStatusCode());
     }
 
     @Test

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageTest.java
@@ -18,6 +18,7 @@ package org.citrusframework.http.message;
 
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -231,7 +232,7 @@ public class HttpMessageTest {
 
 
         //WHEN
-        final HttpStatus statusCode = httpMessage.getStatusCode();
+        final HttpStatusCode statusCode = httpMessage.getStatusCode();
 
         //THEN
         assertNull(statusCode);
@@ -244,7 +245,7 @@ public class HttpMessageTest {
         httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, "404");
 
         //WHEN
-        final HttpStatus statusCode = httpMessage.getStatusCode();
+        final HttpStatusCode statusCode = httpMessage.getStatusCode();
 
         //THEN
         assertEquals(statusCode, HttpStatus.NOT_FOUND);
@@ -257,7 +258,7 @@ public class HttpMessageTest {
         httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, 403);
 
         //WHEN
-        final HttpStatus statusCode = httpMessage.getStatusCode();
+        final HttpStatusCode statusCode = httpMessage.getStatusCode();
 
         //THEN
         assertEquals(statusCode, HttpStatus.FORBIDDEN);
@@ -270,10 +271,23 @@ public class HttpMessageTest {
         httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, HttpStatus.I_AM_A_TEAPOT);
 
         //WHEN
-        final HttpStatus statusCode = httpMessage.getStatusCode();
+        final HttpStatusCode statusCode = httpMessage.getStatusCode();
 
         //THEN
         assertEquals(statusCode, HttpStatus.I_AM_A_TEAPOT);
+    }
+
+    @Test
+    public void testCanHandleCustomStatusCode() {
+
+        //GIVEN
+        httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, 555);
+
+        //WHEN
+        final HttpStatusCode statusCode = httpMessage.getStatusCode();
+
+        //THEN
+        assertEquals(statusCode, HttpStatusCode.valueOf(555));
     }
 
     @Test

--- a/src/manual/validation-hamcrest.adoc
+++ b/src/manual/validation-hamcrest.adoc
@@ -29,6 +29,17 @@ receive("someEndpoint")
         .expression("node-set:/TestRequest/OrderType", hasSize(3));
 ----
 
+NOTE: If you want to match text containing any of the following characters: ' , ( )
+You need to enclose the respective string in quotation marks when defining your matcher.
+If you intend to match an actual single quote, it should be escaped with a backslash (\').
+
+For example:
+[source,xml]
+----
+anyOf(equalTo('text containing a \\' (quote) and a , (comma)  '), anyOf(isEmptyOrNullString()))
+anyOf(equalTo('text containing a backslash and quote \\\\' and a , (comma)  '), anyOf(isEmptyOrNullString()))
+----
+
 .XML
 [source,xml,indent=0,role="secondary"]
 ----

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/HttpCodeProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/HttpCodeProvider.java
@@ -43,7 +43,11 @@ class HttpCodeProvider {
     }
 
     void provideResponseConfiguration(final CodeBlock.Builder code, final HttpMessage message) {
-        code.add(".response($T.$L)\n", HttpStatus.class, message.getStatusCode().name());
+        if (message.getStatusCode() instanceof HttpStatus) {
+            code.add(".response($T.$L)\n", HttpStatus.class, ((HttpStatus) message.getStatusCode()).name());
+        } else {
+            code.add(".response($T.$L)\n", HttpStatus.class, "Status");
+        }
         messageCodeProvider.provideHeaderAndPayload(code, message);
     }
 

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/ReceiveHttpResponseActionProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/ReceiveHttpResponseActionProvider.java
@@ -20,6 +20,7 @@ import org.citrusframework.generate.provider.MessageActionProvider;
 import org.citrusframework.http.message.HttpMessage;
 import org.citrusframework.message.MessageHeaders;
 import org.citrusframework.model.testcase.http.*;
+import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
 
@@ -40,8 +41,13 @@ public class ReceiveHttpResponseActionProvider implements MessageActionProvider<
         response.setBody(body);
 
         ReceiveResponseModel.Headers responseHeaders = new ReceiveResponseModel.Headers();
-        responseHeaders.setStatus(message.getStatusCode().toString());
-        responseHeaders.setReasonPhrase(message.getStatusCode().getReasonPhrase());
+        if (message.getStatusCode() instanceof HttpStatus) {
+            responseHeaders.setStatus(((HttpStatus) message.getStatusCode()).toString());
+            responseHeaders.setReasonPhrase(((HttpStatus) message.getStatusCode()).getReasonPhrase());
+        } else {
+            responseHeaders.setStatus("Status" + message.getStatusCode().value());
+            responseHeaders.setReasonPhrase("Custom Status Code " + message.getStatusCode().value());
+        }
 
         message.getHeaders().entrySet().stream()
                 .filter(entry -> !entry.getKey().startsWith(MessageHeaders.PREFIX))

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/SendHttpResponseActionProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/SendHttpResponseActionProvider.java
@@ -20,6 +20,7 @@ import org.citrusframework.generate.provider.MessageActionProvider;
 import org.citrusframework.http.message.HttpMessage;
 import org.citrusframework.message.MessageHeaders;
 import org.citrusframework.model.testcase.http.*;
+import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
 
@@ -40,8 +41,13 @@ public class SendHttpResponseActionProvider implements MessageActionProvider<Sen
         response.setBody(body);
 
         ResponseHeadersType responseHeaders = new ResponseHeadersType();
-        responseHeaders.setStatus(message.getStatusCode().toString());
-        responseHeaders.setReasonPhrase(message.getStatusCode().getReasonPhrase());
+        if (message.getStatusCode() instanceof HttpStatus) {
+            responseHeaders.setStatus(((HttpStatus) message.getStatusCode()).toString());
+            responseHeaders.setReasonPhrase(((HttpStatus) message.getStatusCode()).getReasonPhrase());
+        } else {
+            responseHeaders.setStatus("Status" + message.getStatusCode().value());
+            responseHeaders.setReasonPhrase("Custom Status Code " + message.getStatusCode().value());
+        }
 
         message.getHeaders().entrySet().stream()
                 .filter(entry -> !entry.getKey().startsWith(MessageHeaders.PREFIX))

--- a/tools/test-generator/src/test/java/org/citrusframework/generate/provider/http/HttpCodeProviderTest.java
+++ b/tools/test-generator/src/test/java/org/citrusframework/generate/provider/http/HttpCodeProviderTest.java
@@ -21,6 +21,7 @@ import org.citrusframework.http.message.HttpMessage;
 import com.squareup.javapoet.CodeBlock;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatusCode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -77,7 +78,7 @@ class HttpCodeProviderTest {
     void testResponseConfiguration() {
 
         //GIVEN
-        message.statusCode(HttpStatus.SC_NOT_FOUND);
+        message.status(HttpStatusCode.valueOf(HttpStatus.SC_NOT_FOUND));
         final String expectedCode = ".response(org.springframework.http.HttpStatus.NOT_FOUND)\n.message()\n";
 
         //WHEN

--- a/validation/citrus-validation-hamcrest/src/main/java/org/citrusframework/validation/matcher/hamcrest/HamcrestValidationMatcher.java
+++ b/validation/citrus-validation-hamcrest/src/main/java/org/citrusframework/validation/matcher/hamcrest/HamcrestValidationMatcher.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.citrusframework.context.TestContext;
@@ -84,11 +85,9 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
         }
 
         String matcherName = matcherExpression.trim().substring(0, matcherExpression.trim().indexOf("("));
-        String[] matcherParameter = matcherExpression.trim().substring(matcherName.length() + 1, matcherExpression.trim().length() - 1).split(",");
 
-        for (int i = 0; i < matcherParameter.length; i++) {
-            matcherParameter[i] = VariableUtils.cutOffSingleQuotes(matcherParameter[i].trim());
-        }
+        String[] matcherParameter = determineNestedMatcherParameters(matcherExpression.trim()
+            .substring(matcherName.length() + 1, matcherExpression.trim().length() - 1));
 
         try {
             Matcher matcher = getMatcher(matcherName, matcherParameter, context);
@@ -125,6 +124,7 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
      * @return
      */
     private Matcher<?> getMatcher(String matcherName, String[] matcherParameter, TestContext context) {
+
         try {
             if (context.getReferenceResolver().isResolvable(matcherName, HamcrestMatcherProvider.class) ||
                     HamcrestMatcherProvider.canResolve(matcherName)) {
@@ -160,7 +160,11 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
 
                     if (matcherExpression.contains("(") && matcherExpression.contains(")")) {
                         String nestedMatcherName = matcherExpression.trim().substring(0, matcherExpression.trim().indexOf("("));
-                        String[] nestedMatcherParameter = matcherExpression.trim().substring(nestedMatcherName.length() + 1, matcherExpression.trim().length() - 1).split(",");
+                        String[] nestedMatcherParameter = matcherExpression.trim()
+                            .substring(
+                                nestedMatcherName.length() + 1,
+                                matcherExpression.trim().length() - 1)
+                            .split(",");
 
                         return (Matcher<?>) matcherMethod.invoke(null, getMatcher(nestedMatcherName, nestedMatcherParameter,context));
                     }
@@ -174,8 +178,13 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
                     List<Matcher<?>> nestedMatchers = new ArrayList<>();
                     for (String matcherExpression : matcherParameter) {
                         String nestedMatcherName = matcherExpression.trim().substring(0, matcherExpression.trim().indexOf("("));
-                        String nestedMatcherParameter = matcherExpression.trim().substring(nestedMatcherName.length() + 1, matcherExpression.trim().length() - 1);
-                        nestedMatchers.add(getMatcher(nestedMatcherName, new String[] { nestedMatcherParameter }, context));
+                        String[] nestedMatcherParameters = determineNestedMatcherParameters(
+                            matcherExpression.trim().
+                                substring(
+                                    nestedMatcherName.length() + 1,
+                                    matcherExpression.trim().length() - 1));
+
+                        nestedMatchers.add(getMatcher(nestedMatcherName, nestedMatcherParameters, context));
                     }
 
                     return (Matcher<?>) matcherMethod.invoke(null, nestedMatchers);
@@ -183,6 +192,9 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
             }
 
             if (matchers.contains(matcherName)) {
+
+                unescapeQuotes(matcherParameter);
+
                 Method matcherMethod = ReflectionUtils.findMethod(Matchers.class, matcherName, String.class);
 
                 if (matcherMethod == null) {
@@ -198,7 +210,9 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
                 Method matcherMethod = ReflectionUtils.findMethod(Matchers.class, matcherName, double.class, double.class);
 
                 if (matcherMethod != null) {
-                    return (Matcher<?>) matcherMethod.invoke(null, Double.valueOf(matcherParameter[0]), matcherParameter.length > 1 ? Double.parseDouble(matcherParameter[1]) : 0.0D);
+                    return (Matcher<?>) matcherMethod.invoke(
+                        null,
+                        Double.valueOf(matcherParameter[0]), matcherParameter.length > 1 ? Double.parseDouble(matcherParameter[1]) : 0.0D);
                 }
 
                 matcherMethod = ReflectionUtils.findMethod(Matchers.class, matcherName, Comparable.class);
@@ -209,6 +223,9 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
             }
 
             if (collectionMatchers.contains(matcherName)) {
+
+                unescapeQuotes(matcherParameter);
+
                 Method matcherMethod = ReflectionUtils.findMethod(Matchers.class, matcherName, int.class);
 
                 if (matcherMethod != null) {
@@ -229,6 +246,9 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
             }
 
             if (mapMatchers.contains(matcherName)) {
+
+                unescapeQuotes(matcherParameter);
+
                 Method matcherMethod =  ReflectionUtils.findMethod(Matchers.class, matcherName, Object.class);
 
                 if (matcherMethod != null) {
@@ -243,6 +263,9 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
             }
 
             if (optionMatchers.contains(matcherName)) {
+
+                unescapeQuotes(matcherParameter);
+
                 Method matcherMethod =  ReflectionUtils.findMethod(Matchers.class, matcherName, Object[].class);
 
                 if (matcherMethod != null) {
@@ -252,7 +275,9 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
                 matcherMethod =  ReflectionUtils.findMethod(Matchers.class, matcherName, Collection.class);
 
                 if (matcherMethod != null) {
-                    return (Matcher<?>) matcherMethod.invoke(null, new Object[] { getCollection(StringUtils.arrayToCommaDelimitedString(matcherParameter)) });
+                    return (Matcher<?>) matcherMethod.invoke(
+                        null,
+                        new Object[] { getCollection(StringUtils.arrayToCommaDelimitedString(matcherParameter)) });
                 }
             }
         } catch (InvocationTargetException | IllegalAccessException e) {
@@ -263,6 +288,18 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
     }
 
     /**
+     * Unescape the quotes in search expressions  (\\' -> ').
+     * @param matcherParameters to unescape
+     */
+    private static void unescapeQuotes(String[] matcherParameters) {
+        if (matcherParameters != null) {
+            for (int i=0; i< matcherParameters.length; i++) {
+                matcherParameters[i] = matcherParameters[i].replace("\\'","'");
+            }
+        }
+    }
+
+    /**
      * Try to find matcher provider using different lookup strategies. Looks into reference resolver and resource path for matcher provider.
      * @param matcherName
      * @param context
@@ -270,7 +307,8 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
      */
     private Optional<HamcrestMatcherProvider> lookupMatcherProvider(String matcherName, TestContext context) {
         // try to find matcher provider via reference
-        Optional<HamcrestMatcherProvider> matcherProvider = context.getReferenceResolver().resolveAll(HamcrestMatcherProvider.class)
+        Optional<HamcrestMatcherProvider> matcherProvider = context.getReferenceResolver()
+            .resolveAll(HamcrestMatcherProvider.class)
                 .values()
                 .stream()
                 .filter(provider -> provider.getName().equals(matcherName))
@@ -363,6 +401,35 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
     }
 
     /**
+     * Extracts parameters for a matcher from the raw parameter expression.
+     * Parameters refer to the contained parameters and matchers (first level),
+     * excluding nested ones.
+     * <p/>
+     * For example, given the expression:<br/>
+     * {@code "oneOf(greaterThan(5.0), allOf(lessThan(-1.0), greaterThan(-2.0)))"}
+     * <p/>
+     * The extracted parameters are:<br/>
+     * {@code "greaterThan(5.0)", "allOf(lessThan(-1.0), greaterThan(-2.0))"}.
+     * <p/>
+     * Note that nested container expressions "allOf(lessThan(-1.0), greaterThan(-2.0))" in
+     * the second parameter are treated as a single expression. They need to be treated
+     * separately in a recursive call to this method, when the parameters for the
+     * respective allOf() expression are extracted.
+     *
+     * @param rawExpression the full parameter expression of a container matcher
+     */
+    public String[] determineNestedMatcherParameters(final String rawExpression) {
+        if (!StringUtils.hasText(rawExpression)) {
+            return new String[0];
+        }
+
+        Tokenizer tokenizer = new Tokenizer();
+        String tokenizedExpression = tokenizer.tokenize(rawExpression);
+        return tokenizer.restoreInto(tokenizedExpression.split(","));
+
+    }
+
+    /**
      * Numeric value comparable automatically converts types to numeric values for
      * comparison.
      */
@@ -418,4 +485,92 @@ public class HamcrestValidationMatcher implements ValidationMatcher, ControlExpr
         }
     }
 
+    /**
+     * Class that provides functionality to replace expressions that match
+     * {@link Tokenizer#TEXT_PARAMETER_PATTERN} with simple tokens of the form $$n$$.
+     * The reason for this is, that complex nested expressions
+     * may contain characters that interfere with further processing - e.g. ''', '(' and ')'
+     */
+    private static class Tokenizer {
+
+        private static final String START_TOKEN = "_TOKEN-";
+
+        private static final String END_TOKEN = "-TOKEN_";
+
+        /**
+         * Regular expression with three alternative parts (ored) to match:
+         * <ol>
+         *   <li> `(sometext)` - Quoted parameter block of a matcher.</li>
+         *   <li> 'sometext' - Quoted text used as a parameter to a string matcher.</li>
+         *   <li> (unquotedtext) - Unquoted text used as a parameter to a string matcher. This expression is non-greedy, meaning the first closing bracket will terminate the match.</li>
+         * </ol>
+         * <p/>
+         * Please note:
+         * - 'sometext' may contain an escaped quote.
+         * - 'unquotedtext' must not contain brackets or commas.
+         * <p/>
+         * To match quotes, commas, or brackets, you must quote the text. To match a quote, it should be escaped with a backslash.
+         * Therefore, the regex expressions explicitly match the escaped quote -> \\\\'
+         */
+        private static final Pattern TEXT_PARAMETER_PATTERN = Pattern.compile(
+            "(?<quoted1>\\('(?:[^']|\\\\')*[^\\\\]'\\))"
+                + "|(?<quoted2>('(?:[^']|\\\\')*[^\\\\]'))"
+                + "|(?<unquoted>\\(((?:[^']|\\\\')*?)[^\\\\]?\\))"
+        );
+
+        private final List<String> originalTokenValues = new ArrayList<>();
+
+        /**
+         * Tokenize the given raw expression
+         *
+         * @param rawExpression
+         * @return the expression with all relevant subexpressions replaced by tokens
+         */
+        public String tokenize(String rawExpression) {
+            java.util.regex.Matcher matcher = TEXT_PARAMETER_PATTERN.matcher(rawExpression);
+            StringBuilder builder = new StringBuilder();
+
+            while (matcher.find()) {
+                String matchedValue = findMatchedValue(matcher);
+                originalTokenValues.add(matchedValue);
+                matcher.appendReplacement(builder, START_TOKEN + originalTokenValues.size() + END_TOKEN);
+            }
+
+            matcher.appendTail(builder);
+            return builder.toString();
+        }
+
+        /**
+         * @param matcher the matcher that was used to match
+         * @return the value of the group, that was actually matched
+         */
+        private String findMatchedValue(java.util.regex.Matcher matcher) {
+            String matchedValue = matcher.group("quoted1");
+            matchedValue = matchedValue != null ? matchedValue : matcher.group("quoted2");
+            return matchedValue != null ? matchedValue : matcher.group("unquoted");
+        }
+
+        /**
+         * Restore the tokens back into the given expressions.
+         *
+         * @param expressions containing strings with tokens, generated by this tokenizer.
+         * @return expressions with the tokens being replaced with their original values.
+         */
+        public String[] restoreInto(String[] expressions) {
+
+            for (int i = 0; i < expressions.length; i++) {
+                expressions[i] = VariableUtils.cutOffSingleQuotes(
+                    replaceTokens(expressions[i], originalTokenValues).trim());
+            }
+
+            return expressions;
+        }
+
+        private String replaceTokens(String expression, List<String> params) {
+            for (int i = 0; i < params.size(); i++) {
+                expression = expression.replace(START_TOKEN + (i + 1) + END_TOKEN, params.get(i));
+            }
+            return expression;
+        }
+    }
 }

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/validation/matcher/hamcrest/HamcrestValidationMatcherTest.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/validation/matcher/hamcrest/HamcrestValidationMatcherTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
  */
 public class HamcrestValidationMatcherTest extends AbstractTestNGUnitTest {
 
-    private HamcrestValidationMatcher validationMatcher = new HamcrestValidationMatcher();
+    private final HamcrestValidationMatcher validationMatcher = new HamcrestValidationMatcher();
 
     @Override
     protected TestContextFactory createTestContextFactory() {
@@ -49,7 +49,7 @@ public class HamcrestValidationMatcherTest extends AbstractTestNGUnitTest {
 
             @Override
             public Matcher<String> provideMatcher(String predicate) {
-                return new CustomMatcher<String>(String.format("path matching %s", predicate)) {
+                return new CustomMatcher<>(String.format("path matching %s", predicate)) {
                     @Override
                     public boolean matches(Object item) {
                         return ((item instanceof String) && new AntPathMatcher().match(predicate, (String) item));
@@ -63,7 +63,7 @@ public class HamcrestValidationMatcherTest extends AbstractTestNGUnitTest {
     }
 
     @Test(dataProvider = "testData")
-    public void testValidate(String path, String value, List<String> params) throws Exception {
+    public void testValidate(String path, String value, List<String> params)  {
         validationMatcher.validate( path, value, params, context);
     }
 
@@ -72,22 +72,35 @@ public class HamcrestValidationMatcherTest extends AbstractTestNGUnitTest {
         return new Object[][] {
             new Object[]{ "foo", "value", Collections.singletonList("equalTo(value)") },
             new Object[]{ "foo", "value", Collections.singletonList("equalTo('value')") },
+            new Object[]{ "foo", "value with ' quote", Collections.singletonList("equalTo('value with \\' quote')") },
+            new Object[]{ "foo", "value with ' quote", Collections.singletonList("equalTo(value with \\' quote)") },
+            new Object[]{ "foo", "value", Collections.singletonList("equalTo('value')") },
             new Object[]{"foo", "value", Collections.singletonList("not(equalTo(other))")},
             new Object[]{"foo", "value", Collections.singletonList("is(not(other))")},
             new Object[]{"foo", "value", Collections.singletonList("not(is(other))")},
             new Object[]{"foo", "value", Collections.singletonList("equalToIgnoringCase(VALUE)")},
+            new Object[]{"foo", "value with ' quote", Collections.singletonList("equalToIgnoringCase(VALUE WITH \\' QUOTE)")},
             new Object[]{"foo", "value", Collections.singletonList("containsString(lue)")},
+            new Object[]{"foo", "value with ' quote", Collections.singletonList("containsString(with \\')")},
+            new Object[]{"foo", "value with ' quote", Collections.singletonList("containsString(\\')")},
+            new Object[]{"foo", "value with ' quote", Collections.singletonList("containsString(value with \\' qu)")},
             new Object[]{"foo", "value", Collections.singletonList("not(containsString(other))")},
             new Object[]{"foo", "value", Collections.singletonList("startsWith(val)")},
+            new Object[]{"foo", "value with ' quote", Collections.singletonList("startsWith(value with \\' q)")},
+            new Object[]{"foo", "value with ' quote", Collections.singletonList("startsWith('value with \\' q')")},
             new Object[]{"foo", "value", Collections.singletonList("endsWith(lue)")},
+            new Object[]{"foo", "value with ' quote", Collections.singletonList("endsWith(th \\' quote)")},
+            new Object[]{"foo", "value with ' quote", Collections.singletonList("endsWith('th \\' quote')")},
             new Object[]{"foo", "value", Collections.singletonList("anyOf(startsWith(val), endsWith(lue))")},
             new Object[]{"foo", "value", Collections.singletonList("allOf(startsWith(val), endsWith(lue))")},
             new Object[]{"foo", "value/12345", Collections.singletonList("matchesPath(value/{id})")},
             new Object[]{"foo", "value/12345/test", Collections.singletonList("matchesPath(value/{id}/test)")},
             new Object[]{"foo", "value", Collections.singletonList("isOneOf(value, other)")},
+            new Object[]{"foo", "value with ' quote", Collections.singletonList("isOneOf('value with \\' quote', 'other')")},
             new Object[]{"foo", "test value", Collections.singletonList("isOneOf('test value', 'other ')")},
             new Object[]{"foo", "9.0", Collections.singletonList("isOneOf(9, 9.0)")},
             new Object[]{"foo", "value", Collections.singletonList("isIn(value, other)")},
+            new Object[]{"foo", "value with ' quote", Collections.singletonList("isIn('value with \\' quote', 'other')")},
             new Object[]{"foo", "test value", Collections.singletonList("isIn('test value', 'other ')")},
             new Object[]{"foo", "9.0", Collections.singletonList("isIn(9, 9.0)")},
             new Object[]{"foo", "", Collections.singletonList("isEmptyString()")},
@@ -116,23 +129,49 @@ public class HamcrestValidationMatcherTest extends AbstractTestNGUnitTest {
             new Object[]{"foo", "", Arrays.asList("9", "lessThanOrEqualTo(9)")},
             new Object[]{"foo", "{value1=value2,value4=value5}", Collections.singletonList("hasSize(2)") },
             new Object[]{"foo", "{value1=value2,value4=value5}", Collections.singletonList("hasEntry(value1,value2)") },
+            new Object[]{"foo", "{value1=value2 with ' quote,value4=value5}", Collections.singletonList("hasEntry(value1,value2 with ' quote)") },
             new Object[]{"foo", "{value1=value2,value4=value5}", Collections.singletonList("hasKey(value1)") },
             new Object[]{"foo", "{\"value1\"=\"value2\",\"value4\"=\"value5\"}", Collections.singletonList("hasKey(value1)") },
-            new Object[]{"foo", "{value1=value2,value4=value5}", Collections.singletonList("hasValue(value2)") },
+            new Object[]{"foo", "{value1=value2 with ' quote,value4=value5}", Collections.singletonList("hasValue(value2 with \\' quote)") },
             new Object[]{"foo", "[value1,value2,value3,value4,value5]", Collections.singletonList("hasSize(5)") },
             new Object[]{"foo", "[value1,value2,value3,value4,value5]", Collections.singletonList("everyItem(startsWith(value))") },
             new Object[]{"foo", "[value1,value2,value3,value4,value5]", Collections.singletonList("hasItem(value2)") },
             new Object[]{"foo", "[value1,value2,value3,value4,value5]", Collections.singletonList("hasItems(value2,value5)") },
+            new Object[]{"foo", "[a,b,c,d,e]", Collections.singletonList("hasItems('a','b','c')") },
+            new Object[]{"foo", "[a,b,c,d,e]", Collections.singletonList("hasItems(a, b, c)") },
+            new Object[]{"foo", "[a'a,b'b,c'c,d'd,e'e]", Collections.singletonList("hasItems('a\\'a','b\\'b','c\\'c')") },
+            new Object[]{"foo", "[a\\'a,b\\'b,c\\'c,d\\'d,e\\'e]", Collections.singletonList("hasItems('a\\\\'a','b\\\\'b','c\\\\'c')") },
             new Object[]{"foo", "[\"value1\",\"value2\",\"value3\",\"value4\",\"value5\"]", Collections.singletonList("hasItems(value2,value5)") },
             new Object[]{"foo", "[value1,value2,value3,value4,value5]", Collections.singletonList("contains(value1,value2,value3,value4,value5)") },
             new Object[]{"foo", "[value1,value2,value3,value4,value5]", Collections.singletonList("containsInAnyOrder(value2,value4,value1,value3,value5)") },
+            new Object[]{"foo", "[a,b,c,d,e]", Collections.singletonList("contains('a','b','c','d','e')") },
+            new Object[]{"foo", "[a,b,c,d,e]", Collections.singletonList("contains(a,b,c,d,e)") },
+            new Object[]{"foo", "[a'a,b'b,c'c,d'd,e'e]", Collections.singletonList("contains('a\\'a','b\\'b','c\\'c','d\\'d','e\\'e')") },
+            new Object[]{"foo", "[a\\'a,b\\'b,c\\'c,d\\'d,e\\'e]", Collections.singletonList("contains('a\\\\'a','b\\\\'b','c\\\\'c','d\\\\'d','e\\\\'e')") },
             new Object[]{"foo", "[\"unique_value\",\"different_unique_value\"]", Collections.singletonList("hasSize(2)") },
-            new Object[]{"foo", "[\"duplicate_value\",\"duplicate_value\"]", Collections.singletonList("hasSize(2)") }
+            new Object[]{"foo", "[\"duplicate_value\",\"duplicate_value\"]", Collections.singletonList("hasSize(2)") },
+            new Object[]{"foo", "text containing a , (comma)  ", Collections.singletonList("anyOf(equalTo('text containing a , (comma)  '), anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "", Collections.singletonList("anyOf(equalTo('text containing a , (comma)  '), anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", null, Collections.singletonList("anyOf(equalTo('text containing a , (comma)  '), anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "text-equalTo(QA, Max", Collections.singletonList("anyOf(equalTo('text-equalTo(QA, Max'),anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "", Collections.singletonList("anyOf(equalTo('text-equalTo(QA, Max'),anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", null, Collections.singletonList("anyOf(equalTo('text-equalTo(QA, Max'),anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "QA-equalTo(HH), Max", Collections.singletonList("anyOf(equalTo('QA-equalTo(HH), Max'),anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "text containing a ' (quote) and a , (comma)  ", Collections.singletonList("anyOf(equalTo('text containing a \\' (quote) and a , (comma)  '), anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "text containing a \\' (backslashquote) and a , (comma)  ", Collections.singletonList("anyOf(equalTo('text containing a \\\\' (backslashquote) and a , (comma)  '), anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "unquoted text may not include brackets or commas", Collections.singletonList("anyOf(equalTo(unquoted text may not include brackets or commas), anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "quoted \\' text may not include brackets or commas", Collections.singletonList("anyOf(equalTo(quoted \\\\' text may not include brackets or commas), anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "value1", Collections.singletonList("anyOf(isEmptyOrNullString(),equalTo(value1))")},
+
+            new Object[]{"foo", "INSERT INTO todo_entries (id, title, description, done) values (1, 'Invite for meeting', 'Invite the group for a lunch meeting', 'false')",
+                Collections.singletonList("allOf(startsWith('INSERT INTO todo_entries (id, title, description, done)'))")},
+
+
         };
     }
 
     @Test(dataProvider = "testDataFailed", expectedExceptions = ValidationException.class)
-    public void testValidateFailed(String path, String value, List<String> params) throws Exception {
+    public void testValidateFailed(String path, String value, List<String> params) {
         validationMatcher.validate( path, value, params, context);
     }
 
@@ -142,6 +181,7 @@ public class HamcrestValidationMatcherTest extends AbstractTestNGUnitTest {
             new Object[]{ "foo", "value", Collections.singletonList("equalTo(wrong)") },
             new Object[]{"foo", "value", Collections.singletonList("not(equalTo(value))")},
             new Object[]{"foo", "value", Collections.singletonList("is(not(value))")},
+            new Object[]{"foo", "val with quote ' ue", Collections.singletonList("is(not(val with quote \\' ue))")},
             new Object[]{"foo", "value", Collections.singletonList("not(is(value))")},
             new Object[]{"foo", "value", Collections.singletonList("equalToIgnoringCase(WRONG)")},
             new Object[]{"foo", "value", Collections.singletonList("containsString(wrong)")},
@@ -190,7 +230,14 @@ public class HamcrestValidationMatcherTest extends AbstractTestNGUnitTest {
             new Object[]{"foo", "[value1,value2]", Collections.singletonList("hasItem(value5)") },
             new Object[]{"foo", "[value1,value2]", Collections.singletonList("hasItems(value1,value2,value5)") },
             new Object[]{"foo", "[value1,value2]", Collections.singletonList("contains(value1)") },
-            new Object[]{"foo", "[value1,value2]", Collections.singletonList("containsInAnyOrder(value2,value4)") }
+            new Object[]{"foo", "[value1,value2]", Collections.singletonList("containsInAnyOrder(value2,value4)") },
+            new Object[]{"foo", "notext-equalTo(QA, Max", Collections.singletonList("anyOf(equalTo('text-equalTo(QA, Max'),anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "aa", Collections.singletonList("anyOf(equalTo('text-equalTo(QA, Max'),anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "VA-equalTo(HH), Max", Collections.singletonList("anyOf(equalTo('QA-equalTo(HH), Max'),anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "notext containing a ' (quote) and a , (comma)  ", Collections.singletonList("anyOf(equalTo('text containing a \\' (quote) and a , (comma)  '), anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "notext containing a \\' (quote) and a , (comma)  ", Collections.singletonList("anyOf(equalTo('text containing a \\\\' (quote) and a , (comma)  '), anyOf(isEmptyOrNullString()))")},
+            new Object[]{"foo", "nounquoted text may not include brackets or commas", Collections.singletonList("anyOf(equalTo(unquoted text may not include brackets or commas), anyOf(isEmptyOrNullString()))")},
+
         };
     }
 }


### PR DESCRIPTION
`HttpMessage.getStatusCode()` is a braeaking change of the methode. Because of the new methode `HttpMessage.status(HttpStatusCode)` we could remove `HttpMessage.statusCode(Integer)` completely. 